### PR TITLE
[BUG FIX] Authentication Fixes

### DIFF
--- a/AugmentedSpace/app/(tabs)/profile.tsx
+++ b/AugmentedSpace/app/(tabs)/profile.tsx
@@ -2,8 +2,9 @@ import { StatusBar } from "expo-status-bar";
 import { Platform, Pressable } from "react-native";
 import { Text, View } from "@/components/Themed";
 import { useTheme } from "@react-navigation/native";
-import { signOut, getAuth } from "firebase/auth";
+import { signOut, getAuth, onAuthStateChanged, User } from "firebase/auth";
 import { router } from "expo-router";
+import { useEffect, useState } from "react";
 
 const signOutAndReroute = async () => {
   await signOut(getAuth());
@@ -12,7 +13,15 @@ const signOutAndReroute = async () => {
 
 export default function ProfileScreen() {
   const { colors } = useTheme();
-  const { currentUser } = getAuth();
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const auth = getAuth();
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setCurrentUser(user);
+    });
+    return () => unsubscribe();
+  }, []);
 
   return (
     <View

--- a/AugmentedSpace/app/logIn.tsx
+++ b/AugmentedSpace/app/logIn.tsx
@@ -1,6 +1,6 @@
 import { Text, View } from "@/components/Themed";
 import { Pressable, TextInput } from "react-native";
-import { getAuth, signInWithEmailAndPassword } from "firebase/auth";
+import { getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
 import { useTheme } from "@react-navigation/native";
 import { router } from "expo-router";
 import { useState, useEffect } from "react";
@@ -19,6 +19,13 @@ export default function LogInScreen() {
 
   const navigateToSignUp = () => {
     router.navigate("/signUp");
+  };
+
+  const handleContinueAsGuest = async () => {
+    if (getAuth().currentUser) {
+      await signOut(getAuth());
+    }
+    resetRouterAndReRoute("/(tabs)");
   };
 
   const handleLogin = () => {
@@ -104,7 +111,7 @@ export default function LogInScreen() {
 
         <Pressable
           className="flex-1 justify-end"
-          onPress={() => resetRouterAndReRoute("/(tabs)")}
+          onPress={handleContinueAsGuest}
         >
           <Text style={{ color: colors.text }}>Continue as Guest</Text>
         </Pressable>

--- a/AugmentedSpace/app/signUp.tsx
+++ b/AugmentedSpace/app/signUp.tsx
@@ -2,7 +2,11 @@ import { Text, View } from "@/components/Themed";
 import { Pressable, TextInput } from "react-native";
 import React, { useState } from "react";
 import { useTheme } from "@react-navigation/native";
-import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
+import {
+  getAuth,
+  createUserWithEmailAndPassword,
+  signOut,
+} from "firebase/auth";
 import { router } from "expo-router";
 import { resetRouterAndReRoute } from "./_layout";
 import { ShowPopup } from "@/components/popup";
@@ -25,6 +29,13 @@ export default function SignUpScreen() {
     } else {
       ShowPopup("Passwords do not match");
     }
+  };
+
+  const handleContinueAsGuest = async () => {
+    if (getAuth().currentUser) {
+      await signOut(getAuth());
+    }
+    resetRouterAndReRoute("/(tabs)");
   };
 
   return (
@@ -130,7 +141,7 @@ export default function SignUpScreen() {
             </Text>
           </Pressable>
         </View>
-        <Pressable onPress={() => resetRouterAndReRoute("/(tabs)")}>
+        <Pressable onPress={handleContinueAsGuest}>
           <Text className="py-6" style={{ color: colors.text }}>
             Continue as Guest
           </Text>


### PR DESCRIPTION
Addressed corner case: User logged in due to auth persistence, but chooses to continue as a guest. This shows the user as a guest but treats them as an authenticated user. Fix prevents users from being logged in to an account while considered a guest.

Updated Profile page authentication: Now refreshes and accurately retrieves user upon page visits. Previously, if logged in after starting as a guest, profile didn't update (remained as guest).